### PR TITLE
Clean up formatting, docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,56 +1,50 @@
-GOTP: golang one-time password generation tool
-==============================================
+GOTP: golang one-time password tool
+===================================
 
 `gotp` is a tool for managing gpg-encrypted [HOTP](https://en.wikipedia.org/wiki/HMAC-based_One-time_Password_Algorithm) and [TOTP](https://en.wikipedia.org/wiki/Time-based_One-time_Password_Algorithm)
 tokens, the kinds of tokens used for two-factor authentication by services
 like AWS, Dropbox, Google, Facebook, etc.
 
-The goal of `gotp` is that a user can securely use their computer, along with
-their gpg key, as a second factor. Due to the nature of gpg, this comes with the
-added benefit that, with some kind of shared storage, the OTP secret could be
-shared between multiple users; for instance, a team with a single account on a
-service could enable two-factor authentication and then encrypt the secret for
-that service with every team member's gpg key.
+With `gotp`, a user can use their computer and their GPG key as a second factor.
+Since it is possible to encrypt a message with multiple GPG keys, it is then also
+possible to share an OTP secret between multiple users; for instance, a team
+with a single account on a service could enable two-factor authentication and
+encrypt the OTP secret with every team member's key.
 
 ```
 $ gotp
-Wed Apr 12 12:15:25 PDT 2017
-aws-dev: 798748
-aws-prod: 205905
-dropbox: 693472
+Mon Jul 10 14:10:44 PDT 2017
+        aws-dev: 180472
+       aws-prod: 837059
+        dropbox: 615562
+ secret-service: HOTP
 ```
 
 Usage
 -----
 
-`gotp` currently requires gpg keys to be specified by full fingerprint. To get
-the fingerprint of your gpg key, the `--fingerprint` gpg command can be used:
+`gotp` encrypts tokens with one or more GPG key. Keys can be specified with either
+a key's 20-byte fingerprint or with the email associated with the key.
 
-```
-$ gpg --fingerprint user@example.com
-pub   4096R/6BADE665 2017-01-25 [expires: 2018-07-19]
-      Key fingerprint = 9D19 556E 2ED7 60E4 1ACA  825D 9026 84E8 9DBC F765
-```
+Enrolling a token is simple. The enroll command takes several parameters:
+* `--token`: the name of the token being enrolled (ex: `github`, `dropbox`)
+* `--emails`: a comma-separated list of emails identifying GPG keys. The first matching GPG key is used; if in doubt, specify using the key's fingerprint. (ex: `me@company.com,coworker@company.com`)
+* `--fingerprints`: a comma-separated list of GPG key fingerprints. The full 20-byte fingerprint is required.
 
-To add a token to `gotp`:
+If you are enrolling an HOTP token, then be sure to pass the `--hotp` flag and the `--counter` flag (default: 0).
 
+Examples:
 ```
-$ gotp enroll --fingerprints 9D19556E2ED760E41ACA825D902684E89DBCF765 --token service-name
+$ gotp enroll --fingerprints 2187... --emails username@company.com --token another-service
 Paste secret:
-2017/04/12 12:25:13 encrypting with key 9d19556e2ed760e41aca825d902684e89dbcf765
+Added token another-service successfully with 2 keys!
 ```
 
 Now, the token is available for use:
 ```
 $ gotp
-Wed Apr 12 12:27:06 PDT 2017
-service-name: 153439
-```
-
-To enroll an `hotp` token, specify `--hotp` and the `--count`:
-
-```
-$ gotp enroll --fingerprints 9D19556E2ED760E41ACA825D902684E89DBCF765 --token hotp-token --hotp --counter 1
+Mon Jul 10 14:26:49 PDT 2017
+ another-service: 961126
 ```
 
 To view the value of an HOTP token, use `increment`. This also increments the counter by one:
@@ -70,3 +64,11 @@ OTP secrets are base32 strings. These can be generated from `/dev/random`:
 $ dd if=/dev/random bs=1 count=40 | base32
 72OT4T6Y357MEK3N7W5YPVMZYK4XH36P2JSEHVJIDAETFU2ZALTLPE7RPZNDOXFZ
 ```
+
+How do I generate a GPG key?
+----------------------------
+
+If using `gotp` is your first time using `GPG`, don't fret! GitHub has good
+documentation on [how to generate your first key](https://help.github.com/articles/generating-a-new-gpg-key/#generating-a-gpg-key).
+After you've generated your key, you can pass the email you generated it
+with to the `--emails` option when enrolling a token.

--- a/cmd/enroll.go
+++ b/cmd/enroll.go
@@ -37,6 +37,8 @@ var enrollCmd = &cobra.Command{
 		err = token.WriteToken(strSecret, tk, fingerprints, emails, hotp, counter)
 		if err != nil {
 			log.Fatal(err)
+		} else {
+			fmt.Printf("Added token %s successfully with %d keys!\n", tk, len(fingerprints)+len(emails))
 		}
 	},
 	PreRunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/increment.go
+++ b/cmd/increment.go
@@ -14,8 +14,8 @@ var tkName string
 
 var incrementCmd = &cobra.Command{
 	Use:   "increment",
-	Short: "increment an hotp token",
-	Long:  `increment an hotp token`,
+	Short: "increment and view HOTP token",
+	Long:  `increment and view HOTP token`,
 	Run: func(cmd *cobra.Command, args []string) {
 		tk, err := token.ReadToken(tkName)
 		if err != nil {
@@ -24,7 +24,7 @@ var incrementCmd = &cobra.Command{
 
 		if tk.Hotp {
 			hotp := &otp.HOTP{Secret: tk.Token, Counter: tk.Counter, IsBase32Secret: true}
-			fmt.Printf("incrementing from %s: %s\n", tk.Name, hotp.Get())
+			fmt.Printf("incrementing %s: %s\n", tk.Name, hotp.Get())
 			err = token.WriteToken(tk.Token, tk.Name, tk.StrFingerprints, nil, true, tk.Counter+1)
 			if err != nil {
 				log.Fatal(err)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/hgfischer/go-otp"
@@ -25,6 +26,20 @@ func getEnvDefault(env string, def string) string {
 	return def
 }
 
+func lengthofLongest(files []os.FileInfo) int {
+	m := 0
+	for _, e := range files {
+		if len(e.Name()) > m {
+			m = len(e.Name())
+		}
+	}
+	return m
+}
+
+func leftPad(str string, length int) string {
+	return strings.Repeat(" ", length-len(str)+1) + str
+}
+
 var RootCmd = &cobra.Command{
 	Use:   "gotp",
 	Short: "one-time password generation tool",
@@ -33,18 +48,19 @@ var RootCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		files, _ := ioutil.ReadDir(tokenDir)
 		fmt.Println(time.Now().Format(time.UnixDate))
+		longest := lengthofLongest(files)
 		for _, f := range files {
 			mode := f.Mode()
 			if mode.IsDir() {
 				tk, err := token.ReadToken(f.Name())
 				if err != nil {
-					log.Fatalf("error reading token %s: %s", f.Name(), err)
+					log.Fatalf("error reading token %s: %s", leftPad(f.Name(), longest), err)
 				}
 				if tk.Hotp {
-					fmt.Printf("HOTP: %s\n", tk.Name)
+					fmt.Printf("HOTP: %s\n", leftPad(tk.Name, longest))
 				} else {
 					totp := &otp.TOTP{Secret: tk.Token, IsBase32Secret: true}
-					fmt.Printf("%s: %s\n", tk.Name, totp.Get())
+					fmt.Printf("%s: %s\n", leftPad(tk.Name, longest), totp.Get())
 				}
 			}
 		}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -57,7 +57,7 @@ var RootCmd = &cobra.Command{
 					log.Fatalf("error reading token %s: %s", leftPad(f.Name(), longest), err)
 				}
 				if tk.Hotp {
-					fmt.Printf("HOTP: %s\n", leftPad(tk.Name, longest))
+					fmt.Printf("%s: %s\n", leftPad(tk.Name, longest), "HOTP")
 				} else {
 					totp := &otp.TOTP{Secret: tk.Token, IsBase32Secret: true}
 					fmt.Printf("%s: %s\n", leftPad(tk.Name, longest), totp.Get())

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -5,7 +5,6 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
-	"strings"
 	"time"
 
 	"github.com/hgfischer/go-otp"
@@ -36,10 +35,6 @@ func lengthofLongest(files []os.FileInfo) int {
 	return m
 }
 
-func leftPad(str string, length int) string {
-	return strings.Repeat(" ", length-len(str)+1) + str
-}
-
 var RootCmd = &cobra.Command{
 	Use:   "gotp",
 	Short: "one-time password generation tool",
@@ -54,13 +49,13 @@ var RootCmd = &cobra.Command{
 			if mode.IsDir() {
 				tk, err := token.ReadToken(f.Name())
 				if err != nil {
-					log.Fatalf("error reading token %s: %s", leftPad(f.Name(), longest), err)
+					log.Fatalf("error reading token %*s: %s", longest, f.Name(), err)
 				}
 				if tk.Hotp {
-					fmt.Printf("%s: %s\n", leftPad(tk.Name, longest), "HOTP")
+					fmt.Printf(" %*s: %s\n", longest, tk.Name, "HOTP")
 				} else {
 					totp := &otp.TOTP{Secret: tk.Token, IsBase32Secret: true}
-					fmt.Printf("%s: %s\n", leftPad(tk.Name, longest), totp.Get())
+					fmt.Printf(" %*s: %s\n", longest, tk.Name, totp.Get())
 				}
 			}
 		}

--- a/token/token.go
+++ b/token/token.go
@@ -288,6 +288,10 @@ func Decrypt(encoded []byte) ([]byte, error) {
 	encodedReader := bytes.NewReader(encoded)
 	md, err := openpgp.ReadMessage(encodedReader, keyring, pr, nil)
 	if err != nil {
+		if strings.Contains(err.Error(), "PROGRESS need_entropy") {
+			fmt.Print("gpg-agent needs more entropy; please try again!\n")
+			os.Exit(1)
+		}
 		return nil, err
 	}
 


### PR DESCRIPTION
Changes the formatting of token name so that tokens are left-padded / center aligned with the tokens lining up. Makes things look nice :)

before
```
tschuy@localhost:(gotp)(master) → ./gotp
Mon Jul 10 11:56:26 PDT 2017
aws-dev: 085224
aws-prod: 872936
dropbox: 869866
service-name: 917607
service-two: 917607
test: 905159
testdual: 735092
```

after:
```
Mon Jul 10 11:56:03 PDT 2017
      aws-dev: 085224
     aws-prod: 872936
      dropbox: 869866
 service-name: 917607
  service-two: 917607
         test: 735462
     testdual: 735092
```