### PR TITLE
Add minor compatibility errors, deduplicate directory definitions, and a tiny bit more gpg-agent compatibility

### DIFF
--- a/gotp.go
+++ b/gotp.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"strconv"
@@ -8,21 +9,37 @@ import (
 	"github.com/tschuy/gotp/cmd"
 )
 
+var systemdSocket = "/run/user/" + strconv.FormatInt(int64(os.Getuid()), 10) + "/gnupg/S.gpg-agent"
+var homeSocket = os.Getenv("HOME") + "/.gnupg/S.gpg-agent"
+
+// how can we connect to GPG Agent? there are a few ways:
+//   * gpg-agent before v2: stored in GPG_AGENT_INFO
+//   * gpg-agent after v2: stored in "a stable pathname now", according to the Debian docs
+//		* on systemd, this means /run/user/[uid]/gnupg/S.gpg-agent
+//		* in general, $HOME/.gnupg/S.gpg-agent
+// https://wiki.debian.org/Teams/GnuPG/UsingGnuPGv2#GPG_AGENT_INFO_variable
+func setupSocket() error {
+	if os.Getenv("GPG_AGENT_INFO") != "" {
+		return nil
+	}
+	if _, err := os.Stat(systemdSocket); !os.IsNotExist(err) {
+		os.Setenv("GPG_AGENT_INFO", systemdSocket+":12345:1")
+		return nil
+	}
+	if _, err := os.Stat(homeSocket); !os.IsNotExist(err) {
+		os.Setenv("GPG_AGENT_INFO", homeSocket+":12345:1")
+		return nil
+	}
+
+	return errors.New("unable to find gpg-agent")
+}
+
 func main() {
-	if _, err := os.Stat("/run/user/" + strconv.FormatInt(int64(os.Getuid()), 10) + "/gnupg/S.gpg-agent"); os.IsNotExist(err) && os.Getenv("GPG_AGENT_INFO") == "" {
-		fmt.Print("Unable to find gpg-agent; is it running?\n")
+	err := setupSocket()
+	if err != nil {
+		fmt.Println("Could not find gpg-agent; is it running?")
 		os.Exit(1)
 	}
 
-	// how can we connect to GPG Agent? there are a few ways:
-	//   * gpg-agent before v2: stored in GPG_AGENT_INFO
-	//   * gpg-agent after v2: stored in "a stable pathname now", according to the Debian docs
-	//		* on systemd, this means /run/user/[uid]/gnupg/S.gpg-agent
-	//		* on other init systems that don't use FHS, let alone other OSes, more research is necessary
-	// https://wiki.debian.org/Teams/GnuPG/UsingGnuPGv2#GPG_AGENT_INFO_variable
-	if os.Getenv("GPG_AGENT_INFO") == "" {
-		os.Setenv("GPG_AGENT_INFO",
-			"/run/user/"+strconv.FormatInt(int64(os.Getuid()), 10)+"/gnupg/S.gpg-agent:12345:1")
-	}
 	cmd.Execute()
 }

--- a/gotp.go
+++ b/gotp.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"os"
 	"strconv"
 
@@ -8,8 +9,20 @@ import (
 )
 
 func main() {
-	// horrible hack
-	os.Setenv("GPG_AGENT_INFO",
-		"/run/user/"+strconv.FormatInt(int64(os.Getuid()), 10)+"/gnupg/S.gpg-agent:12345:1")
+	if _, err := os.Stat("/run/user/" + strconv.FormatInt(int64(os.Getuid()), 10) + "/gnupg/S.gpg-agent"); os.IsNotExist(err) && os.Getenv("GPG_AGENT_INFO") == "" {
+		fmt.Print("Unable to find gpg-agent; is it running?\n")
+		os.Exit(1)
+	}
+
+	// how can we connect to GPG Agent? there are a few ways:
+	//   * gpg-agent before v2: stored in GPG_AGENT_INFO
+	//   * gpg-agent after v2: stored in "a stable pathname now", according to the Debian docs
+	//		* on systemd, this means /run/user/[uid]/gnupg/S.gpg-agent
+	//		* on other init systems that don't use FHS, let alone other OSes, more research is necessary
+	// https://wiki.debian.org/Teams/GnuPG/UsingGnuPGv2#GPG_AGENT_INFO_variable
+	if os.Getenv("GPG_AGENT_INFO") == "" {
+		os.Setenv("GPG_AGENT_INFO",
+			"/run/user/"+strconv.FormatInt(int64(os.Getuid()), 10)+"/gnupg/S.gpg-agent:12345:1")
+	}
 	cmd.Execute()
 }

--- a/gpg/gpg.go
+++ b/gpg/gpg.go
@@ -1,0 +1,61 @@
+package gpg
+
+import (
+	"errors"
+	"os"
+
+	"golang.org/x/crypto/openpgp"
+)
+
+var prefix = os.Getenv("HOME")
+var gpgHome = getEnvDefault("GNUPGHOME", prefix)
+var secretKeyring = gpgHome + "/.gnupg/secring.gpg"
+var publicKeyring = gpgHome + "/.gnupg/pubring.gpg"
+
+func getEnvDefault(env string, def string) string {
+	if s := os.Getenv(env); s != "" {
+		return s
+	}
+	return def
+}
+
+// returns the private gnupg keystore from disk
+func GetPrivateKeyRing() (*openpgp.EntityList, error) {
+	var entityList openpgp.EntityList
+
+	// Open the private key file
+	keyringFileBuffer, err := os.Open(secretKeyring)
+	if err != nil {
+		return nil, err
+	}
+	defer keyringFileBuffer.Close()
+
+	entityList, err = openpgp.ReadKeyRing(keyringFileBuffer)
+	if err != nil {
+		return nil, err
+	}
+
+	return &entityList, nil
+}
+
+// returns the public gnupg keystore from disk
+func GetPublicKeyRing() (*openpgp.EntityList, error) {
+	var entityList openpgp.EntityList
+
+	// Open the public key file
+	keyringFileBuffer, err := os.Open(publicKeyring)
+	if err != nil {
+		if _, err := os.Stat(gpgHome + "/.gnupg/pubring.kbx"); !os.IsNotExist(err) {
+			return nil, errors.New("not compatible with kbx keyring")
+		}
+		return nil, err
+	}
+	defer keyringFileBuffer.Close()
+
+	entityList, err = openpgp.ReadKeyRing(keyringFileBuffer)
+	if err != nil {
+		return nil, err
+	}
+
+	return &entityList, nil
+}


### PR DESCRIPTION
I think this comment sums up my opinion of gpg-agent:

```
+	// how can we connect to GPG Agent? there are a few ways:
--
  |   |   | +	//   * gpg-agent before v2: stored in GPG_AGENT_INFO
  |   |   | +	//   * gpg-agent after v2: stored in "a stable pathname now", according to the Debian docs
  |   |   | +	//		* on systemd, this means /run/user/[uid]/gnupg/S.gpg-agent
  |   |   | +	//		* on other init systems that don't use FHS, let alone other OSes, more research is necessary
  |   |   | +	// https://wiki.debian.org/Teams/GnuPG/UsingGnuPGv2#GPG_AGENT_INFO_variable
```

This PR fixes a number of small things.

* better error for GPGv2 kbx users
* don't clobber existing GPG_AGENT_INFO
* only declare file locations one time (in new `gpg/gpg.go`)