### PR TITLE
add delete command

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,19 @@ Wed Apr 12 12:27:06 PDT 2017
 hotp-token: 535293
 ```
 
+To delete a token:
+
+```
+$ gotp delete -t another-service
+Are you sure you want to remove token another-service? y/[N] y
+Deleting token another-service...
+Token deleted successfully!
+```
+
+If you wish to remove without prompting, the `--force/-f` parameter removes this check.
+The delete command simply removes the directory `$HOME/.otptokens/[tokenname]`.
+
+
 Generating Testing Tokens
 -------------------------
 

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -1,0 +1,60 @@
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"log"
+
+	"strings"
+
+	"os"
+
+	"github.com/spf13/cobra"
+	"github.com/tschuy/gotp/token"
+)
+
+var f bool
+
+var deleteCmd = &cobra.Command{
+	Use:   "delete",
+	Short: "delete a token",
+	Long:  `delete a token`,
+	Run: func(cmd *cobra.Command, args []string) {
+		if !f {
+			var ans string
+			fmt.Printf("Are you sure you want to remove token %s? y/[N] ", tk)
+			_, err := fmt.Scanln(&ans)
+			if err != nil {
+				log.Fatal(err)
+			}
+			if !(strings.HasPrefix(ans, "y") || strings.HasPrefix(ans, "Y")) {
+				fmt.Println("cancelling operation!")
+				return
+			}
+		}
+		fmt.Printf("Deleting token %s...\n", tk)
+		err := token.DeleteToken(tk)
+		if err != nil && os.IsNotExist(err) {
+			fmt.Printf("Could not find token %s\n", tk)
+			os.Exit(1)
+		} else if err != nil {
+			fmt.Print("Could not delete token: ")
+			log.Fatal(err)
+		} else {
+			fmt.Println("Token deleted successfully!")
+		}
+	},
+	PreRunE: func(cmd *cobra.Command, args []string) error {
+		if tk == "" {
+			return errors.New("--token name is required")
+		}
+		return nil
+	},
+}
+
+func init() {
+	RootCmd.AddCommand(deleteCmd)
+
+	deleteCmd.Flags().StringVarP(&tk, "token", "t", "", "name of token")
+	deleteCmd.Flags().BoolVarP(&f, "force", "f", false, "force removal (do not prompt)")
+}

--- a/token/token.go
+++ b/token/token.go
@@ -58,8 +58,18 @@ func hexStringsToByteSlices(strings []string) ([][]byte, error) {
 	return byteslices, nil
 }
 
-// read token tkName from inside tokenstore dir.
-// unmarshals info to return a token with EncryptedToken
+// DeleteToken : delete token tkName from disk
+func DeleteToken(tkName string) error {
+	path := TokenDir + "/" + tkName
+	_, err := os.Stat(path)
+	if err != nil {
+		return err
+	}
+	return os.RemoveAll(path)
+}
+
+// ReadToken : read tkName from inside tokenstore dir and
+// unmarshal info to return a token with EncryptedToken
 // and Fingerprints info
 func ReadToken(tkName string) (Token, error) {
 	var jk JsonToken


### PR DESCRIPTION
This allows users to delete tokens from within the cli, instead of having to manually delete the token directory. Fixes #13 