### PR TITLE
tell the user when no data is received in paste

### DIFF
--- a/cmd/enroll.go
+++ b/cmd/enroll.go
@@ -24,7 +24,7 @@ var enrollCmd = &cobra.Command{
 	Short: "enroll a new token",
 	Long:  `enroll a new token`,
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("Paste secret: ")
+		fmt.Print("Paste secret: ")
 		byteSecret, err := terminal.ReadPassword(int(syscall.Stdin))
 		if err != nil {
 			log.Fatal(err)

--- a/token/token.go
+++ b/token/token.go
@@ -38,6 +38,9 @@ type Token struct {
 }
 
 func Verify(secret string) error {
+	if secret == "" {
+		return errors.New("hmm, doesn't look like I got anything. Are you using the correct paste buffer?")
+	}
 	_, err := base32.StdEncoding.DecodeString(secret)
 	if err != nil {
 		return errors.New("invalid secret (was not base32!)")


### PR DESCRIPTION
hopefully at least a little better than silently adding a nothing-token.

it's not a fix, but ref #12 -- we would like the user to be aware if they're not using the correct paste buffer. At least this will allow them to see they've not pasted anything, if their terminal paste buffer is empty.

It also fixes the bug that allows you to set an empty secret.