### PR TITLE
Add token export using qrencode

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,8 +70,7 @@ The delete command simply removes the directory `$HOME/.otptokens/[tokenname]`.
 ### Exporting
 
 Two-factor tokens are commonly shared through QR codes. `gotp` can generate a QR code for
-any token it currently has internally. This requires the tool `qrencode` to be installed
-(it can be installed through your package manager, or gotten from the [`qrencode` website](https://fukuchi.org/works/qrencode)).
+any token it currently has internally.
 
 **The exported token contains the secret key and service name. Treat it carefully!**
 

--- a/README.md
+++ b/README.md
@@ -67,6 +67,18 @@ Token deleted successfully!
 If you wish to remove without prompting, the `--force/-f` parameter removes this check.
 The delete command simply removes the directory `$HOME/.otptokens/[tokenname]`.
 
+### Exporting
+
+Two-factor tokens are commonly shared through QR codes. `gotp` can generate a QR code for
+any token it currently has internally. This requires the tool `qrencode` to be installed
+(it can be installed through your package manager, or gotten from the [`qrencode` website](https://fukuchi.org/works/qrencode)).
+
+**The exported token contains the secret key and service name. Treat it carefully!**
+
+```
+$ gotp export -t my-token
+(pretty unicode qr code here)
+```
 
 Generating Testing Tokens
 -------------------------

--- a/cmd/export.go
+++ b/cmd/export.go
@@ -4,10 +4,12 @@ import (
 	"errors"
 	"fmt"
 	"log"
-	"os/exec"
+	"os"
 
 	"github.com/spf13/cobra"
 	"github.com/tschuy/gotp/token"
+
+	"github.com/qpliu/qrencode-go/qrencode"
 )
 
 var exportCmd = &cobra.Command{
@@ -27,16 +29,11 @@ var exportCmd = &cobra.Command{
 			str = fmt.Sprintf("otpauth://totp/%s?secret=%s", tk.Name, tk.Token)
 		}
 
-		// TODO use a golang library that can do the text qr generation itself
-		// qrencode is not a default nor *particularly* common
-		disp := exec.Command("qrencode", str, "-t", "utf8")
-		out, err := disp.Output()
+		grid, err := qrencode.Encode(str, qrencode.ECLevelL)
 		if err != nil {
-			log.Fatal("Could not generate QR code. Do you have qrencode installed?")
+			panic(err)
 		}
-
-		fmt.Printf("%s", out)
-		disp.Wait()
+		grid.TerminalOutput(os.Stdout)
 	},
 	PreRunE: func(cmd *cobra.Command, args []string) error {
 		if tkName == "" {

--- a/cmd/export.go
+++ b/cmd/export.go
@@ -1,0 +1,52 @@
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"log"
+	"os/exec"
+
+	"github.com/spf13/cobra"
+	"github.com/tschuy/gotp/token"
+)
+
+var exportCmd = &cobra.Command{
+	Use:   "export",
+	Short: "export a totp token",
+	Long:  `export a totp token`,
+	Run: func(cmd *cobra.Command, args []string) {
+		tk, err := token.ReadToken(tkName)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		var str string
+		if tk.Hotp {
+			str = fmt.Sprintf("otpauth://hotp/%s?secret=%s&counter=%d", tk.Name, tk.Token, tk.Counter)
+		} else {
+			str = fmt.Sprintf("otpauth://totp/%s?secret=%s", tk.Name, tk.Token)
+		}
+
+		// TODO use a golang library that can do the text qr generation itself
+		// qrencode is not a default nor *particularly* common
+		disp := exec.Command("qrencode", str, "-t", "utf8")
+		out, err := disp.Output()
+		if err != nil {
+			log.Fatal("Could not generate QR code. Do you have qrencode installed?")
+		}
+
+		fmt.Printf("%s", out)
+		disp.Wait()
+	},
+	PreRunE: func(cmd *cobra.Command, args []string) error {
+		if tkName == "" {
+			return errors.New("--token name is required")
+		}
+		return nil
+	},
+}
+
+func init() {
+	RootCmd.AddCommand(exportCmd)
+	exportCmd.Flags().StringVarP(&tkName, "token", "t", "", "name of token to export")
+}


### PR DESCRIPTION
~~~This uses the qrencode binary, which isn't a default install. It'd be ideal to use a library that generates the UTF8 output itself, but as far as I can tell that isn't an option unless I take the time to write one myself, which I'll do in all that free time I have /s~~~

Found a library. It works great. This should be good to go, if it's a feature we want.