### PR TITLE
Allow unpadded secrets

### DIFF
--- a/token/token.go
+++ b/token/token.go
@@ -39,8 +39,11 @@ func Verify(secret string) error {
 	if secret == "" {
 		return errors.New("hmm, doesn't look like I got anything. Are you using the correct paste buffer?")
 	}
-	_, err := base32.StdEncoding.DecodeString(secret)
-	if err != nil {
+	// Google says the badding 'should be omitted', but it doesn't say it must be, so we need to support both.
+	// https://github.com/google/google-authenticator/wiki/Key-Uri-Format#secret
+	_, err1 := base32.StdEncoding.DecodeString(secret)
+	_, err2 := base32.StdEncoding.WithPadding(base32.NoPadding).DecodeString(secret)
+	if err1 != nil && err2 != nil {
 		return errors.New("invalid secret (was not base32!)")
 	}
 	return nil

--- a/token/token_test.go
+++ b/token/token_test.go
@@ -1,0 +1,28 @@
+package token
+
+import "testing"
+
+func TestVerify(t *testing.T) {
+	validSecrets := []string{
+		"JBSWY3DPEHPK3PXP",
+		"HXDMVJECJJWSRB3HWIZR4IFUGFTMXBOZ",
+		"MZXW6CQ=", // With optional, discouraged, padding
+	}
+	invalidSecrets := []string{
+		"hi",
+		"",
+	}
+
+	for _, secret := range validSecrets {
+		if err := Verify(secret); err != nil {
+			t.Errorf("%q should be valid secret, got err: %v", secret, err)
+		}
+	}
+
+	for _, secret := range invalidSecrets {
+		if err := Verify(secret); err == nil {
+			t.Errorf("%q should be invalid secret; got no err", secret)
+		}
+	}
+
+}


### PR DESCRIPTION
As specified
[here](https://github.com/google/google-authenticator/wiki/Key-Uri-Format#secret),
it's recommended that padding is not included in the secret.

Without this change, the tool would error out that the secret is not
base32 if an implemnetor followed google's recommendation there.

With this change, everything else seems to work, so it was just the
validation that bailed, not an underlying library.